### PR TITLE
게시글 페이지가 10페이지 이상 안보이던 현상 수정 (#5)

### DIFF
--- a/src/main/java/hyeong/lee/myboard/controller/BoardController.java
+++ b/src/main/java/hyeong/lee/myboard/controller/BoardController.java
@@ -4,6 +4,7 @@ import hyeong.lee.myboard.dto.BoardResponseDto;
 import hyeong.lee.myboard.service.BoardService;
 import hyeong.lee.myboard.service.PagingService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/boards")
 @Controller
@@ -28,7 +30,7 @@ public class BoardController {
     public String index(@PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable,
                         Model model) {
         Page<BoardResponseDto> boards = boardService.readAll(pageable);
-        List<Integer> paginationNumbers = pagingService.getPaginationNumbers(boards.getPageable());
+        List<Integer> paginationNumbers = pagingService.getPaginationNumbers(pageable.getPageNumber(), boards.getTotalPages());
 
         model.addAttribute("boards", boards);
         model.addAttribute("paginationNumbers", paginationNumbers);

--- a/src/main/java/hyeong/lee/myboard/service/PagingService.java
+++ b/src/main/java/hyeong/lee/myboard/service/PagingService.java
@@ -1,6 +1,5 @@
 package hyeong.lee.myboard.service;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,9 +11,9 @@ public class PagingService {
 
     private final int DEFAULT_BAR_LENGTH = 5;
 
-    public List<Integer> getPaginationNumbers(Pageable pageable) {
-        int startNumber = Math.max(pageable.getPageNumber() - (DEFAULT_BAR_LENGTH / 2), 0); // 항상 0보다 크도록 세팅
-        int endNumber = Math.min(startNumber + DEFAULT_BAR_LENGTH, pageable.getPageSize()); // 최댓값보다 클 수 없음
+    public List<Integer> getPaginationNumbers(int currentPage, int totalPage) {
+        int startNumber = Math.max(currentPage - (DEFAULT_BAR_LENGTH / 2), 0); // 항상 0보다 크도록 세팅
+        int endNumber = Math.min(startNumber + DEFAULT_BAR_LENGTH, totalPage); // 최댓값보다 클 수 없음
 
         return IntStream.range(startNumber, endNumber).boxed().collect(Collectors.toList());
     }


### PR DESCRIPTION
- 총 페이지 수는 Page 인터페이스의 `getTotalPages()` 로 불러와야 함
- 현재 페이지 수는 pageable 인터페이스의 `getPageNumber()`로 가져와야 함