### PR TITLE
게시글 첨부파일이 없는 경우에 대한 조건 수정

### DIFF
--- a/src/main/java/hyeong/lee/myboard/controller/BoardApiController.java
+++ b/src/main/java/hyeong/lee/myboard/controller/BoardApiController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/hyeong/lee/myboard/service/BoardService.java
+++ b/src/main/java/hyeong/lee/myboard/service/BoardService.java
@@ -62,8 +62,8 @@ public class BoardService {
         Board board = dto.toEntity();
         Board savedBoard = boardRepository.save(board);
         try {
-            // 첨부파일이 있는경우 저장
-            if(dto.getFiles() != null) {
+            // 첨부파일이 있는경우 저장 (첨부파일이 없는 경우 NULL이 오는 것이 아니라 길이 1짜리 빈배열이 전달됨)
+            if(!(dto.getFiles().length == 1 && dto.getFiles()[0].isEmpty())) {
                 fileService.saveFile(board, dto.getFiles());
             }
         } catch (IOException e) {


### PR DESCRIPTION
- 게시글 첨부파일이 없는 경우 폼에서 값을 보내지 않거나 null을 보내는 것이 아니라 길이 1짜리 빈 배열을 보내고 있었음
- 근데 파일 하나만 보내면 그 역시 길이 1짜리 배열을 보냄
- 때문에 파일 배열의 길이가 1이면서 "값이 비어있으면(isEmpty)" 첨부파일이 없는것으로 걸러내도록 함