### PR TITLE
입력 폼 검증 실패 시 검증 문구 출력 안되는 이슈 수정

### DIFF
--- a/src/main/java/hyeong/lee/myboard/controller/UserAccountController.java
+++ b/src/main/java/hyeong/lee/myboard/controller/UserAccountController.java
@@ -1,16 +1,9 @@
 package hyeong.lee.myboard.controller;
 
-import hyeong.lee.myboard.dto.request.UserSignUpRequestDto;
-import hyeong.lee.myboard.service.UserAccountService;
-import hyeong.lee.myboard.validator.SignUpUserValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -18,24 +11,9 @@ import javax.validation.Valid;
 @Controller
 public class UserAccountController {
 
-    private final UserAccountService userAccountService;
-    private final SignUpUserValidator signUpUserValidator;
-
-    @InitBinder
-    protected void initBinder(WebDataBinder dataBinder) {
-        dataBinder.addValidators(signUpUserValidator);
-    }
-
     @GetMapping("/sign-up")
     public String getSignUpForm() {
         return "auth/sign-up";
     }
 
-
-    @ResponseBody
-    @PostMapping("/sign-up")
-    public ResponseEntity<String> signUp(@Valid @RequestBody UserSignUpRequestDto dto) {
-        userAccountService.create(dto);
-        return ResponseEntity.ok("OK");
-    }
 }

--- a/src/main/java/hyeong/lee/myboard/exception/ExceptionRestControllerAdvice.java
+++ b/src/main/java/hyeong/lee/myboard/exception/ExceptionRestControllerAdvice.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
-@RestControllerAdvice(basePackages = "hyeong.lee.myboard.controller.restcontroller")
+@RestControllerAdvice(basePackages = "hyeong.lee.myboard.restcontroller")
 public class ExceptionRestControllerAdvice {
 
     private final MessageSource messageSource;

--- a/src/main/java/hyeong/lee/myboard/restcontroller/BoardApiController.java
+++ b/src/main/java/hyeong/lee/myboard/restcontroller/BoardApiController.java
@@ -1,4 +1,4 @@
-package hyeong.lee.myboard.controller.restcontroller;
+package hyeong.lee.myboard.restcontroller;
 
 import hyeong.lee.myboard.domain.UserAccount;
 import hyeong.lee.myboard.dto.request.BoardRequestDto;

--- a/src/main/java/hyeong/lee/myboard/restcontroller/ReplyApiController.java
+++ b/src/main/java/hyeong/lee/myboard/restcontroller/ReplyApiController.java
@@ -1,4 +1,4 @@
-package hyeong.lee.myboard.controller.restcontroller;
+package hyeong.lee.myboard.restcontroller;
 
 import hyeong.lee.myboard.domain.UserAccount;
 import hyeong.lee.myboard.dto.request.ReplyRequestDto;

--- a/src/main/java/hyeong/lee/myboard/restcontroller/UserAccountApiController.java
+++ b/src/main/java/hyeong/lee/myboard/restcontroller/UserAccountApiController.java
@@ -1,0 +1,31 @@
+package hyeong.lee.myboard.restcontroller;
+
+import hyeong.lee.myboard.dto.request.UserSignUpRequestDto;
+import hyeong.lee.myboard.service.UserAccountService;
+import hyeong.lee.myboard.validator.SignUpUserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@RestController
+public class UserAccountApiController {
+
+    private final UserAccountService userAccountService;
+    private final SignUpUserValidator signUpUserValidator;
+
+    @InitBinder
+    protected void initBinder(WebDataBinder dataBinder) {
+        dataBinder.addValidators(signUpUserValidator);
+    }
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<String> signUp(@Valid @RequestBody UserSignUpRequestDto dto) {
+        userAccountService.create(dto);
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/resources/static/js/userAccount-func.js
+++ b/src/main/resources/static/js/userAccount-func.js
@@ -13,7 +13,7 @@ function create_user() {
 
         $.ajax({
             type: 'POST',
-            url: '/user/sign-up',
+            url: '/api/user/sign-up',
             data: JSON.stringify(create_user_data),
             datatype: 'JSON',
             contentType: 'application/json; charset=utf-8',

--- a/src/main/resources/templates/auth/sign-up.html
+++ b/src/main/resources/templates/auth/sign-up.html
@@ -13,7 +13,7 @@
         <div class="col-6">
           <h4 class="mb-3 text-center">회원가입</h4>
           <hr>
-          <form id="userSignUpForm" action="/user/sign-up" method="post">
+          <form id="userSignUpForm" action="/api/user/sign-up" method="post">
             <div class="row g-3">
               <div class="mb-3">
                 <div class="input-group">


### PR DESCRIPTION
`@RestControllerAdvice`의 basePackage와 `@ControllerAdvice`와 basePackage가 겹쳐있었기 때문에 RestControllerAdvice에서 처리되어야 할 Exception이 ControllerAdvice에서 처리되어버려 검증 문구가 원하는대로 출력되지 않고 있었음.
(controller 패키지 내부에 restcontroller 패키지를 사용하고 있었다)

-> @Controller와 @RestController의 `디렉토리를 아예 분리`함으로써 서로 패키지가 겹치지 않도록 수정하였음.

* 커밋을 왜 상세히 남겨야 하는지 알 수 있었다.. 대체 어디서부터 안되던건지 감조차 안왔던 문제여서 일일히 git reset을 통해 되돌아가면서 문제가 생긴 부분을 파악해낼 수 있었다.


This closes #33 