### PR TITLE
회원가입 성공 시 이메일 발송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
     // Config
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/hyeong/lee/myboard/MyBoardApplication.java
+++ b/src/main/java/hyeong/lee/myboard/MyBoardApplication.java
@@ -3,8 +3,10 @@ package hyeong.lee.myboard;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
-@ConfigurationPropertiesScan("hyeong.lee.myboard.config")
+@EnableAsync
+@ConfigurationPropertiesScan("hyeong.lee.myboard.dto.properties")
 @SpringBootApplication
 public class MyBoardApplication {
 

--- a/src/main/java/hyeong/lee/myboard/config/EmailConfig.java
+++ b/src/main/java/hyeong/lee/myboard/config/EmailConfig.java
@@ -1,0 +1,44 @@
+package hyeong.lee.myboard.config;
+
+import hyeong.lee.myboard.dto.properties.EmailProperties;
+import hyeong.lee.myboard.helper.MockEmailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Map;
+import java.util.Properties;
+
+@RequiredArgsConstructor
+@Configuration
+public class EmailConfig {
+
+    private final EmailProperties emailProperties;
+
+    /**
+     * 실제 메일 전송 안하는 MockMailSender() 기본 사용
+     * -> 실제 메일 전송하려면 JavaMailSenderImpl() 사용하면 됨
+     */
+    @Bean
+    public JavaMailSender mailSender() {
+        return new MockEmailSender(); // 실제 메일 전송 X. 5초간 대기
+
+        // 실제 메일 전송
+//        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+//        javaMailSender.setHost(emailProperties.getHost());
+//        javaMailSender.setUsername(emailProperties.getUsername());
+//        javaMailSender.setPassword(emailProperties.getPassword());
+//        javaMailSender.setPort(emailProperties.getPort());
+//
+//        Map<String, String> propMap = emailProperties.getProperties();
+//        Properties javaMailProperties = new Properties();
+//        for (String key : propMap.keySet()) {
+//            javaMailProperties.put(key, propMap.get(key));
+//        }
+//        javaMailSender.setJavaMailProperties(javaMailProperties);
+//
+//        return javaMailSender;
+    }
+}

--- a/src/main/java/hyeong/lee/myboard/config/WebMvcConfig.java
+++ b/src/main/java/hyeong/lee/myboard/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package hyeong.lee.myboard.config;
 
+import hyeong.lee.myboard.dto.properties.MyProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;

--- a/src/main/java/hyeong/lee/myboard/dto/properties/EmailProperties.java
+++ b/src/main/java/hyeong/lee/myboard/dto/properties/EmailProperties.java
@@ -1,0 +1,21 @@
+package hyeong.lee.myboard.dto.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "spring.mail")
+@ConstructorBinding
+public class EmailProperties {
+
+    private final String host;
+    private final int port;
+    private final String username;
+    private final String password;
+    private final Map<String, String> properties;
+}

--- a/src/main/java/hyeong/lee/myboard/dto/properties/MyProperties.java
+++ b/src/main/java/hyeong/lee/myboard/dto/properties/MyProperties.java
@@ -1,4 +1,4 @@
-package hyeong.lee.myboard.config;
+package hyeong.lee.myboard.dto.properties;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/hyeong/lee/myboard/event/CustomEventListener.java
+++ b/src/main/java/hyeong/lee/myboard/event/CustomEventListener.java
@@ -1,5 +1,6 @@
 package hyeong.lee.myboard.event;
 
+import hyeong.lee.myboard.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -11,9 +12,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class CustomEventListener {
 
+    private final EmailService emailService;
+
     @Async
     @EventListener
     public void handleUserRegisterEvent(UserRegisterEvent event) {
         log.info("Handling UserRegisterEvent - {}", event.getUserAccount().getUserId());
+        log.info(">> 메일 전송 준비");
+        emailService.sendEmail("회원가입을 환영합니다!",
+                "회원가입 하신 것을 환영합니다, " + event.getUserAccount().getNickname() + "님!",
+                event.getUserAccount().getEmail());
+        log.info("<< 메일 전송 완료 - To.{}", event.getUserAccount().getEmail());
     }
 }

--- a/src/main/java/hyeong/lee/myboard/event/CustomEventListener.java
+++ b/src/main/java/hyeong/lee/myboard/event/CustomEventListener.java
@@ -1,0 +1,19 @@
+package hyeong.lee.myboard.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomEventListener {
+
+    @Async
+    @EventListener
+    public void handleUserRegisterEvent(UserRegisterEvent event) {
+        log.info("Handling UserRegisterEvent - {}", event.getUserAccount().getUserId());
+    }
+}

--- a/src/main/java/hyeong/lee/myboard/event/CustomEventPublisher.java
+++ b/src/main/java/hyeong/lee/myboard/event/CustomEventPublisher.java
@@ -1,0 +1,20 @@
+package hyeong.lee.myboard.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomEventPublisher {
+
+    private final ApplicationEventPublisher publisher;
+
+    public void publishCustomEvent(ApplicationEvent event) {
+        log.info("Publishing Custom Event - {}", event.getSource());
+        publisher.publishEvent(event);
+    }
+}

--- a/src/main/java/hyeong/lee/myboard/event/UserRegisterEvent.java
+++ b/src/main/java/hyeong/lee/myboard/event/UserRegisterEvent.java
@@ -1,0 +1,16 @@
+package hyeong.lee.myboard.event;
+
+import hyeong.lee.myboard.domain.UserAccount;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UserRegisterEvent extends ApplicationEvent {
+
+    private final UserAccount userAccount;
+
+    public UserRegisterEvent(Object source, UserAccount userAccount) {
+        super(source);
+        this.userAccount = userAccount;
+    }
+}

--- a/src/main/java/hyeong/lee/myboard/helper/MockEmailSender.java
+++ b/src/main/java/hyeong/lee/myboard/helper/MockEmailSender.java
@@ -1,0 +1,61 @@
+package hyeong.lee.myboard.helper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Component;
+
+import javax.mail.internet.MimeMessage;
+import java.io.InputStream;
+
+@Slf4j
+@Component
+public class MockEmailSender implements JavaMailSender {
+
+    @Override
+    public MimeMessage createMimeMessage() {
+        return null;
+    }
+
+    @Override
+    public MimeMessage createMimeMessage(InputStream contentStream) throws MailException {
+        return null;
+    }
+
+    @Override
+    public void send(MimeMessage mimeMessage) throws MailException {
+
+    }
+
+    @Override
+    public void send(MimeMessage... mimeMessages) throws MailException {
+
+    }
+
+    @Override
+    public void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
+
+    }
+
+    @Override
+    public void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
+
+    }
+
+    @Override
+    public void send(SimpleMailMessage simpleMessage) throws MailException {
+        try {
+            Thread.sleep(5000); // 5초동안 아무것도 안함
+        } catch (InterruptedException e) {
+            throw new MailSendException("error while send email");
+        }
+    }
+
+    @Override
+    public void send(SimpleMailMessage... simpleMessages) throws MailException {
+
+    }
+}

--- a/src/main/java/hyeong/lee/myboard/service/EmailService.java
+++ b/src/main/java/hyeong/lee/myboard/service/EmailService.java
@@ -1,0 +1,24 @@
+package hyeong.lee.myboard.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendEmail(String title, String content, String receiver) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(receiver);
+        message.setSubject(title);
+        message.setText(content);
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/hyeong/lee/myboard/service/FileService.java
+++ b/src/main/java/hyeong/lee/myboard/service/FileService.java
@@ -1,6 +1,6 @@
 package hyeong.lee.myboard.service;
 
-import hyeong.lee.myboard.config.MyProperties;
+import hyeong.lee.myboard.dto.properties.MyProperties;
 import hyeong.lee.myboard.domain.Board;
 import hyeong.lee.myboard.domain.UploadFile;
 import hyeong.lee.myboard.repository.UploadFileRepository;

--- a/src/main/java/hyeong/lee/myboard/service/UserAccountService.java
+++ b/src/main/java/hyeong/lee/myboard/service/UserAccountService.java
@@ -2,6 +2,8 @@ package hyeong.lee.myboard.service;
 
 import hyeong.lee.myboard.domain.UserAccount;
 import hyeong.lee.myboard.dto.request.UserSignUpRequestDto;
+import hyeong.lee.myboard.event.CustomEventPublisher;
+import hyeong.lee.myboard.event.UserRegisterEvent;
 import hyeong.lee.myboard.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,12 +18,18 @@ import javax.persistence.EntityNotFoundException;
 public class UserAccountService {
 
     private final UserAccountRepository userAccountRepository;
+    private final CustomEventPublisher publisher;
     private final PasswordEncoder passwordEncoder;
 
     // 회원가입
     public void create(UserSignUpRequestDto dto) {
+        // 1. 회원 생성
         UserAccount userAccount = dto.toEntity(passwordEncoder); // Password는 BCrypt 암호화 이후 저장
-        userAccountRepository.save(userAccount);
+        UserAccount savedUserAccount = userAccountRepository.save(userAccount);
+
+        // 2. 회원 생성 알림 발송 (비동기)
+        UserRegisterEvent userRegisterEvent = new UserRegisterEvent(this, savedUserAccount);
+        publisher.publishCustomEvent(userRegisterEvent);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,17 @@ spring:
     static-path-pattern: /resources/** # 정적 리소스에 접근할 때는 항상 아래 경로로 요청
   messages: # 메세지 소스 설정
     basename: errors
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: [내 이메일 ID]
+    password: [내 이메일 PW]
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls.enable: true
 
 # 저장소 경로 변수
 my.resourcesPath: C:\Users\HOME\Desktop\Java_study\MySimpleBoardService\storage

--- a/src/test/java/hyeong/lee/myboard/service/FileServiceTest.java
+++ b/src/test/java/hyeong/lee/myboard/service/FileServiceTest.java
@@ -1,6 +1,6 @@
 package hyeong.lee.myboard.service;
 
-import hyeong.lee.myboard.config.MyProperties;
+import hyeong.lee.myboard.dto.properties.MyProperties;
 import hyeong.lee.myboard.domain.Board;
 import hyeong.lee.myboard.domain.UploadFile;
 import hyeong.lee.myboard.repository.UploadFileRepository;


### PR DESCRIPTION
회원가입 로직 처리 중 이메일 전송은 `비동기`로 처리함
- `@EnableAsync`, `@Async`를 이용해서 비동기 메서드를 쉽게 만들 수 있음

실제 메일을 전송하는 객체와 메일을 전송하지 않는 객체 두 가지를 만들어둠
- 실제 메일을 전송하는 객체의 경우 아예 전부 자동으로 주입받으면 관계가 없는데 EmailConfig에서 내가 직접 new 키워드로 JavaMailSender를 만들면 설정 파일 매핑이 자동으로 안되는 단점이 있음..
- 그래서 ConfigurationPropertiesScan 이용해서 클래스로 매핑시킨 다음에 수동으로 다 set 해줌

This closes #42 